### PR TITLE
gh-action: Removal of custom crun binary

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -157,22 +157,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: aws
     steps:
-      - name: patch crun (Workaround for https://github.com/actions/runner-images/issues/9425)
-        run: |
-          tmpdir="$(mktemp -d)"
-          pushd "$tmpdir"
-          curl -Lo ./crun https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64
-          GOOD_SHA=80c5ab9422d4672f650f2bad3da933568349b64117d055486abc3534517be2af
-          sha256sum ./crun
-          OUR_SHA=$(sha256sum ./crun | awk '{ print $1 }')
-          if [[ "$GOOD_SHA" == "$OUR_SHA" ]]; then
-              sudo install crun /usr/bin/crun
-          else
-              echo "Checksums do not match"
-              exit 1
-          fi
-          popd
-          rm -rf "$tmpdir"
       - uses: actions/checkout@v4
       - name: setup binfmt_misc
         run: sudo podman run --privileged ghcr.io/gardenlinux/binfmt_container >/dev/null 2>&1


### PR DESCRIPTION
Same procedure as in https://github.com/gardenlinux/gardenlinux/pull/2242


----
- Starting with the GitHub image runner version `20240225.1.0` podman/crun stopped working correctly. Rough summary is that the used kernel and crun 0.17 did not play well together. 
- @fwilhe introduced a workaround by using the binary release of crun 1.14.3
- The bug was fixed in ubuntu package 0.17+dfsg-1.1ubuntu0.1
- The workaround is most likely no longer needed. @fwilhe and I tested successfully with the current runner version (`20240721.1.0`, `ubuntu-latest`) and without the workaround
- I also checked that the current runner has crun 0.17+dfsg-1.1ubuntu0.1 
- This PR reverts the workaround so that the crun version that comes with the runner image is used.

https://github.com/actions/runner-images/issues/9425#issuecomment-1966373104 (runner bugreport)
https://bugs.launchpad.net/cloud-images/+bug/2056442 (issue at ubuntu)
https://github.com/gardenlinux/gardenlinux/commit/9f6f9c53633330795bae68b3e94b1366698cfdb3 (workaround)
https://launchpad.net/ubuntu/+source/crun/0.17+dfsg-1.1ubuntu0.1 (fixed version)
https://github.com/fwilhe/jubilant-funicular/actions/runs/10197364403/job/28210045524 (@fwilhe 's run)
https://github.com/mxmxchere/gl-action/actions/runs/10196668968/job/28207883622 (my run)
https://github.com/mxmxchere/gl-action/actions/runs/10202473206/job/28226655108#step:2:15 (crun version output)